### PR TITLE
Fix typo in date

### DIFF
--- a/chapter_7.rb
+++ b/chapter_7.rb
@@ -122,5 +122,5 @@ v.schedulable?(starting, ending)
 m = Mechanic.new
 m.schedulable?(starting, ending)
 # This Mechanic is not scheduled
-#   between 2012-02-29 and 2015-09-10
+#   between 2015-08-31 and 2015-09-10
 #  => true


### PR DESCRIPTION
This corrects a typo (wrong date) in the comment for the mechanic object on p. 153.
In the printed book it has been partially corrected, but the month and day are still wrong.
