### PR TITLE
Correct typo in RecumbentBike output

### DIFF
--- a/chapter_6.rb
+++ b/chapter_6.rb
@@ -767,5 +767,5 @@ end
 bent = RecumbentBike.new(flag: 'tall and orange')
 bent.spares
 # -> {:tire_size => "28",
-#     :chain     => "10-speed",
+#     :chain     => "9-speed",
 #     :flag      => "tall and orange"}


### PR DESCRIPTION
The output is correct in the Sixth Printing March 2016, but the source code here does not match.